### PR TITLE
Make printable invoice layout editable

### DIFF
--- a/Rechnungen/Windows/Bill.xaml
+++ b/Rechnungen/Windows/Bill.xaml
@@ -57,6 +57,8 @@
                   Width="197"/>
             <Button Click="btnDrucken_Click" x:Name="btnDrucken" Content="Drucken" HorizontalAlignment="Right"
               Margin="0,0,99,14" VerticalAlignment="Bottom" Width="86" Height="32" IsEnabled="False"/>
+            <Button Click="btnLayout_Click" x:Name="btnLayout" Content="Layout" HorizontalAlignment="Right"
+              Margin="0,0,190,14" VerticalAlignment="Bottom" Width="86" Height="32" IsEnabled="False"/>
             <ComboBox SelectionChanged="cboRabatt_SelectionChanged" x:Name="cboRabatt" HorizontalAlignment="Left"
                 Margin="78,76,0,0" VerticalAlignment="Top" Width="512"/>
             <Label x:Name="lblRabatt" Content="Rabatt" HorizontalContentAlignment="Right"
@@ -87,7 +89,7 @@
                VerticalAlignment="Bottom" Width="195" IsReadOnlyCaretVisible="True" IsEnabled="False"
                Foreground="Lime" FontSize="16" FontWeight="Bold"/>
             <Button Click="btnMail_Click" x:Name="btnMail" Content="Email" HorizontalAlignment="Right"
-              Margin="0,0,190,14" VerticalAlignment="Bottom" Width="86" Height="32" IsEnabled="False"/>
+              Margin="0,0,281,14" VerticalAlignment="Bottom" Width="86" Height="32" IsEnabled="False"/>
             <ComboBox SelectionChanged="cboRabatt_SelectionChanged" x:Name="cboZusatztext" HorizontalAlignment="Left"
                 Margin="79,106,0,0" VerticalAlignment="Top" Width="512"/>
             <Label x:Name="lblZusatztext" Content="Zusatz" HorizontalContentAlignment="Right"

--- a/Rechnungen/Windows/Bill.xaml.cs
+++ b/Rechnungen/Windows/Bill.xaml.cs
@@ -15,6 +15,7 @@ using Microsoft.Win32;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
 using Rechnungen.Dialogs;
+using Rechnungen.Windows;
 
 namespace Rechnungen.Windows
 {
@@ -212,6 +213,7 @@ namespace Rechnungen.Windows
 
             btnDrucken.IsEnabled = ID.HasValue;
             btnMail.IsEnabled = ID.HasValue;
+            btnLayout.IsEnabled = ID.HasValue;
 
             if (!ID.HasValue)
                 return;
@@ -351,6 +353,24 @@ namespace Rechnungen.Windows
         private void dgrPositionen_CurrentCellChanged(object sender, EventArgs e)
         {
             SetSummenAnzeige();
+        }
+
+        private void btnLayout_Click(object sender, RoutedEventArgs e)
+        {
+            var selected = GetSelectedRechnung();
+
+            if (selected == null)
+            {
+                MessageBox.Show("Bitte wählen Sie zuerst eine Rechnung aus.", "Rechnungslayout", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var layout = new BillPrintLayout(selected, User)
+            {
+                Owner = this
+            };
+
+            layout.ShowDialog();
         }
     }
 }

--- a/Rechnungen/Windows/BillPrintLayout.xaml
+++ b/Rechnungen/Windows/BillPrintLayout.xaml
@@ -1,0 +1,140 @@
+<Window x:Class="Rechnungen.Windows.BillPrintLayout"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d"
+        Title="Rechnungsdruck" Height="950" Width="720" Icon="/logo.jpg">
+    <Grid Background="#f7f7f7">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <DockPanel Margin="10" Grid.Row="0">
+            <Button x:Name="btnPrint" Width="110" Height="32" Margin="0,0,10,0" Content="Drucken"
+                    Click="btnPrint_Click" HorizontalAlignment="Left"/>
+            <Button x:Name="btnClose" Width="110" Height="32" Content="Schließen" Click="btnClose_Click"/>
+        </DockPanel>
+
+        <ScrollViewer Grid.Row="1" Margin="10" VerticalScrollBarVisibility="Auto">
+            <Border Background="White" Padding="20" BorderThickness="1" BorderBrush="#DDD" CornerRadius="6">
+                <Grid x:Name="LayoutRoot" Margin="0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <!-- Header -->
+                    <Grid Grid.Row="0" Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="*"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="0" Spacing="4">
+                            <TextBlock Text="Rechnung" FontSize="26" FontWeight="Bold"/>
+                            <TextBlock Text="Rechnungsnummer" FontWeight="SemiBold"/>
+                            <TextBox Text="" x:Name="txtRechnungsNummer" MinWidth="160"/>
+                            <TextBlock Text="Datum" FontWeight="SemiBold" Margin="0,8,0,0"/>
+                            <TextBox Text="" x:Name="txtRechnungsDatum"/>
+                            <TextBlock Text="Leistungsdatum" FontWeight="SemiBold" Margin="0,8,0,0"/>
+                            <TextBox Text="" x:Name="txtLeistungsdatum"/>
+                        </StackPanel>
+                        <StackPanel Grid.Column="1" HorizontalAlignment="Right" Spacing="4" Width="300">
+                            <TextBlock Text="Eigene Firma" FontWeight="SemiBold"/>
+                            <TextBox x:Name="txtFirma" TextWrapping="Wrap" AcceptsReturn="True"/>
+                            <TextBox x:Name="txtAdresse" TextWrapping="Wrap" AcceptsReturn="True"/>
+                            <TextBox x:Name="txtKontakt" TextWrapping="Wrap" AcceptsReturn="True"/>
+                            <TextBox x:Name="txtBank" TextWrapping="Wrap" AcceptsReturn="True"/>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Kunde -->
+                    <Border Grid.Row="1" Background="#f0f4ff" Padding="12" CornerRadius="4" BorderBrush="#d5def7" BorderThickness="1" Margin="0,0,0,16">
+                        <StackPanel Spacing="6">
+                            <TextBlock Text="Kunde" FontSize="16" FontWeight="SemiBold"/>
+                            <TextBox x:Name="txtKunde" TextWrapping="Wrap" AcceptsReturn="True"/>
+                            <TextBox x:Name="txtKundenAdresse" TextWrapping="Wrap" AcceptsReturn="True"/>
+                            <TextBox x:Name="txtKundenKontakt" TextWrapping="Wrap" AcceptsReturn="True"/>
+                        </StackPanel>
+                    </Border>
+
+                    <!-- Freier Text oben -->
+                    <StackPanel Grid.Row="2" Margin="0,0,0,16">
+                        <TextBlock Text="Freier Text (oben)" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <TextBox x:Name="txtFreitextOben" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="80"/>
+                    </StackPanel>
+
+                    <!-- Positionen -->
+                    <StackPanel Grid.Row="3" Margin="0,0,0,16">
+                        <TextBlock Text="Leistungspositionen" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                          <DataGrid x:Name="dgPositionen" AutoGenerateColumns="False" HeadersVisibility="Column"
+                                    IsReadOnly="False" CanUserAddRows="True" CanUserDeleteRows="True" Margin="0,4,0,0"
+                                    RowEditEnding="dgPositionen_RowEditEnding">
+                              <DataGrid.Columns>
+                                  <DataGridTextColumn Header="#" Binding="{Binding Nummer}" Width="60"/>
+                                  <DataGridTextColumn Header="Beschreibung" Binding="{Binding Beschreibung}" Width="*"/>
+                                  <DataGridTextColumn Header="Menge" Binding="{Binding Menge}" Width="100"/>
+                                  <DataGridTextColumn Header="Einzelpreis" Binding="{Binding Einzelpreis}" Width="120"/>
+                                  <DataGridTextColumn Header="Gesamt" Binding="{Binding Gesamt}" Width="120"/>
+                              </DataGrid.Columns>
+                          </DataGrid>
+                      </StackPanel>
+
+                    <!-- Summen -->
+                    <Grid Grid.Row="4" Margin="0,0,0,16">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="260"/>
+                        </Grid.ColumnDefinitions>
+                        <StackPanel Grid.Column="1" Spacing="6" HorizontalAlignment="Right">
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" JustifyContent="SpaceBetween">
+                                <TextBlock Text="Netto"/>
+                                <TextBox x:Name="txtNetto" FontWeight="SemiBold" TextAlignment="Right" MinWidth="140"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" JustifyContent="SpaceBetween">
+                                <TextBlock Text="Rabatt"/>
+                                <TextBox x:Name="txtRabatt" FontWeight="SemiBold" TextAlignment="Right" MinWidth="140"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" JustifyContent="SpaceBetween">
+                                <TextBlock Text="Umsatzsteuer"/>
+                                <TextBox x:Name="txtSteuer" FontWeight="SemiBold" TextAlignment="Right" MinWidth="140"/>
+                            </StackPanel>
+                            <Border BorderBrush="#222" BorderThickness="0,0,0,1" Margin="0,4"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" JustifyContent="SpaceBetween">
+                                <TextBlock Text="Gesamt" FontSize="16" FontWeight="Bold"/>
+                                <TextBox x:Name="txtGesamt" FontSize="16" FontWeight="Bold" TextAlignment="Right" MinWidth="140"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </Grid>
+
+                    <!-- Freier Text unten -->
+                    <StackPanel Grid.Row="5" Margin="0,0,0,16">
+                        <TextBlock Text="Freier Text (unten)" FontWeight="SemiBold" Margin="0,0,0,6"/>
+                        <TextBox x:Name="txtFreitextUnten" AcceptsReturn="True" TextWrapping="Wrap" MinHeight="120"/>
+                    </StackPanel>
+
+                    <!-- Abschluss -->
+                        <StackPanel Grid.Row="6" Margin="0,0,0,12" Spacing="4">
+                            <TextBlock Text="Dank für Ihr Vertrauen" FontWeight="SemiBold"/>
+                            <TextBox x:Name="txtSignature" Height="60" TextWrapping="Wrap" AcceptsReturn="True"
+                                     ToolTip="Unterschrift"/>
+                        </StackPanel>
+
+                    <!-- Fußzeile -->
+                        <StackPanel Grid.Row="7" Spacing="2">
+                            <TextBlock Text="Bank- und Kontaktinformationen" FontWeight="SemiBold"/>
+                            <TextBox x:Name="txtFooterBank" TextWrapping="Wrap" AcceptsReturn="True"/>
+                            <TextBox x:Name="txtFooterKontakt" TextWrapping="Wrap" AcceptsReturn="True"/>
+                        </StackPanel>
+                </Grid>
+            </Border>
+        </ScrollViewer>
+    </Grid>
+</Window>

--- a/Rechnungen/Windows/BillPrintLayout.xaml.cs
+++ b/Rechnungen/Windows/BillPrintLayout.xaml.cs
@@ -1,0 +1,136 @@
+using DATA;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Rechnungen.Windows
+{
+    public partial class BillPrintLayout : Window
+    {
+        private readonly Rechnung rechnung;
+        private readonly Benutzer benutzer;
+        private readonly ObservableCollection<LayoutPosition> layoutPositions = new ObservableCollection<LayoutPosition>();
+
+        public BillPrintLayout(Rechnung rechnung, Benutzer benutzer)
+        {
+            InitializeComponent();
+            this.rechnung = rechnung ?? throw new ArgumentNullException(nameof(rechnung));
+            this.benutzer = benutzer ?? new Benutzer();
+
+            BuildHeader();
+            BuildClientSection();
+            BuildPositions();
+            BuildTotals();
+            BuildTexts();
+            BuildFooter();
+        }
+
+        private void BuildHeader()
+        {
+            txtRechnungsNummer.Text = $"{rechnung.Nr}";
+            txtRechnungsDatum.Text = rechnung.Datum.ToShortDateString();
+            txtLeistungsdatum.Text = rechnung.LeistungsDatum.ToShortDateString();
+
+            txtFirma.Text = !string.IsNullOrWhiteSpace(benutzer.FirmaName) ? benutzer.FirmaName : "Eigene Firma";
+            if (benutzer.addresse != null)
+                txtAdresse.Text = benutzer.addresse.ToString();
+
+            var kontakt = string.Join(" | ", new[] { benutzer.Telefone, benutzer.Email }.Where(v => !string.IsNullOrWhiteSpace(v)));
+            txtKontakt.Text = kontakt;
+            var bank = string.Join(" | ", new[] { benutzer.BankName, $"IBAN: {benutzer.IBAN}", $"BIC: {benutzer.BIC}" }
+                .Where(v => !string.IsNullOrWhiteSpace(v)));
+            txtBank.Text = bank;
+        }
+
+        private void BuildClientSection()
+        {
+            txtKunde.Text = rechnung.Kunde?.FirmaName;
+            txtKundenAdresse.Text = rechnung.Kunde?.addresse?.ToString();
+            var kontakt = string.Join(" | ", new[] { rechnung.Kunde?.Telephone, rechnung.Kunde?.Email }.Where(v => !string.IsNullOrWhiteSpace(v)));
+            txtKundenKontakt.Text = kontakt;
+        }
+
+        private void BuildPositions()
+        {
+            layoutPositions.Clear();
+
+            var rows = rechnung.Positions?
+                .Select((p, index) => new LayoutPosition
+                {
+                    Nummer = (index + 1).ToString(),
+                    Beschreibung = p.Beschreibung,
+                    Menge = p.Menge.ToString(),
+                    Einzelpreis = $"{p.Einzeln_Preis:F2} €",
+                    Gesamt = $"{(p.Einzeln_Preis * p.Menge):F2} €"
+                }).ToList();
+
+            if (rows != null)
+            {
+                foreach (var row in rows)
+                {
+                    layoutPositions.Add(row);
+                }
+            }
+
+            dgPositionen.ItemsSource = layoutPositions;
+        }
+
+        private void BuildTotals()
+        {
+            txtNetto.Text = $"{rechnung.Netto():F2} €";
+            txtRabatt.Text = $"-{rechnung.Rabatt():F2} €";
+            txtSteuer.Text = $"+{rechnung.Steuer():F2} €";
+            txtGesamt.Text = $"{rechnung.Summe():F2} €";
+        }
+
+        private void BuildTexts()
+        {
+            txtFreitextOben.Text = rechnung.ZusatzText?.position1 ?? rechnung.ZusatzText?.position2 ?? string.Empty;
+            txtFreitextUnten.Text = rechnung.ZusatzText?.position4 ?? rechnung.ZusatzText?.position5 ?? string.Empty;
+        }
+
+        private void BuildFooter()
+        {
+            txtFooterBank.Text = string.Join(" | ", new[] { benutzer.BankName, $"IBAN: {benutzer.IBAN}", $"BIC: {benutzer.BIC}" }
+                .Where(v => !string.IsNullOrWhiteSpace(v)));
+            txtFooterKontakt.Text = string.Join(" | ", new[] { benutzer.Email, benutzer.Web }
+                .Where(v => !string.IsNullOrWhiteSpace(v)));
+        }
+
+        private void dgPositionen_RowEditEnding(object sender, DataGridRowEditEndingEventArgs e)
+        {
+            if (e.EditAction == DataGridEditAction.Commit && e.Row?.Item is LayoutPosition position)
+            {
+                if (string.IsNullOrWhiteSpace(position.Nummer))
+                {
+                    position.Nummer = (layoutPositions.IndexOf(position) + 1).ToString();
+                }
+            }
+        }
+
+        private void btnPrint_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new PrintDialog();
+            if (dialog.ShowDialog() == true)
+            {
+                dialog.PrintVisual(LayoutRoot, $"Rechnung {rechnung.Nr}");
+            }
+        }
+
+        private void btnClose_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private class LayoutPosition
+        {
+            public string Nummer { get; set; }
+            public string Beschreibung { get; set; }
+            public string Menge { get; set; }
+            public string Einzelpreis { get; set; }
+            public string Gesamt { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make all invoice fields in the printable layout editable, including header, customer, totals, and footer
- allow editing and adding positions directly in the layout grid via an editable collection
- keep free-text areas and signature box ready for customization before printing

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941444e3ecc8332a72a03f3054221a1)